### PR TITLE
Fix shoting balloon make game crash on 1.20.1

### DIFF
--- a/common/src/main/kotlin/org/valkyrienskies/tournament/blocks/BalloonBlock.kt
+++ b/common/src/main/kotlin/org/valkyrienskies/tournament/blocks/BalloonBlock.kt
@@ -66,7 +66,7 @@ open class BalloonBlock : Block(
             val table = TournamentLootTables.BALLOON_POP
             val ctx = LootParams.Builder(level)
                 .withLuck(shooter?.luck ?: 0f)
-                .create(LootContextParamSets.PIGLIN_BARTER)
+                .create(LootContextParamSets.EMPTY)
             val loot = level.server.lootData.getLootTable(table).getRandomItems(ctx)
 
             loot.forEach { itemStack ->


### PR DESCRIPTION
Roll back to `EMPTY`.